### PR TITLE
fix a runtime error on Raspberry pi zero

### DIFF
--- a/adafruit_hcsr04.py
+++ b/adafruit_hcsr04.py
@@ -94,14 +94,20 @@ class HCSR04:
             sensor before assuming it isn't going to answer. Should *not* be
             set to less than 0.05 seconds!
         """
+        global _USE_PULSEIO
         self._timeout = timeout
         self._trig = DigitalInOut(trigger_pin)
         self._trig.direction = Direction.OUTPUT
 
         if _USE_PULSEIO:
-            self._echo = PulseIn(echo_pin)
-            self._echo.pause()
-            self._echo.clear()
+            try:
+                self._echo = PulseIn(echo_pin)
+                self._echo.pause()
+                self._echo.clear()
+            except RuntimeError:
+                _USE_PULSEIO = False
+                self._echo = DigitalInOut(echo_pin)
+                self._echo.direction = Direction.INPUT
         else:
             self._echo = DigitalInOut(echo_pin)
             self._echo.direction = Direction.INPUT


### PR DESCRIPTION
I have a Raspberry pi zero w(Buster), it imports pulseio without error, but it seems to be unable to create a PulseIn at [this line](https://github.com/adafruit/Adafruit_CircuitPython_HCSR04/blob/master/adafruit_hcsr04.py#L102) and produce a runtime error, if I change _USE_PULSEIO to False manually, the problem's gone