### PR TITLE
Update to the correct distance call

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,12 +99,12 @@ Without a Context Manager
 -------------------------
 
 In the example below, we create the `HCSR04` object directly, get the distance every 2 seconds, then
-de-initialize the device. Note trig and echo should come from the `board` module - they aren't just integers.
+de-initialize the device.
 
 ::
-
+    import board
     from adafruit_hcsr04 import HCSR04
-    sonar = HCSR04(trig, echo)
+    sonar = HCSR04(trigger_pin=board.D5, echo_pin=board.D6)
     try:
         while True:
             print(sonar.distance)
@@ -122,9 +122,9 @@ instance, again get the distance every 2 seconds, but then the context manager h
 us.
 
 ::
-
+    import board
     from adafruit_hcsr04 import HCSR04
-    with HCSR04(trig, echo) as sonar:
+    with HCSR04(trigger_pin=board.D5, echo_pin=board.D6) as sonar:
         try:
             while True:
                 print(sonar.distance)

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Without a Context Manager
 -------------------------
 
 In the example below, we create the `HCSR04` object directly, get the distance every 2 seconds, then
-de-initialize the device.
+de-initialize the device. Note trig and echo should come from the `board` module - they aren't just integers.
 
 ::
 
@@ -107,7 +107,7 @@ de-initialize the device.
     sonar = HCSR04(trig, echo)
     try:
         while True:
-            print(sonar.dist_cm())
+            print(sonar.distance)
             sleep(2)
     except KeyboardInterrupt:
         pass
@@ -127,7 +127,7 @@ us.
     with HCSR04(trig, echo) as sonar:
         try:
             while True:
-                print(sonar.dist_cm())
+                print(sonar.distance)
                 sleep(2)
         except KeyboardInterrupt:
             pass

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ See Also:
         <http://circuitpython.readthedocs.io/en/latest/docs/pyboard/tutorial/repl.html>`_ (the guide linked was written
         for the pyboard, but it still works), then input the following:
 
-        ::
+        .. code-block:: python
 
             import board
             dir(board)
@@ -101,7 +101,8 @@ Without a Context Manager
 In the example below, we create the `HCSR04` object directly, get the distance every 2 seconds, then
 de-initialize the device.
 
-::
+.. code-block:: python
+
     import board
     from adafruit_hcsr04 import HCSR04
     sonar = HCSR04(trigger_pin=board.D5, echo_pin=board.D6)
@@ -121,7 +122,8 @@ In the example below, we use a context manager (the `with <https://docs.python.o
 instance, again get the distance every 2 seconds, but then the context manager handles de-initializing the device for
 us.
 
-::
+.. code-block:: python
+
     import board
     from adafruit_hcsr04 import HCSR04
     with HCSR04(trigger_pin=board.D5, echo_pin=board.D6) as sonar:


### PR DESCRIPTION
It looks like the `distance property replaces the `dist_cm()` function. 
Also gave a hint here that the board pin objects are needed, and not just integers.