### PR TITLE
keep _USE_PULSEIO false for NotImplementedError (allows Jetson Nano Support)

### DIFF
--- a/adafruit_hcsr04.py
+++ b/adafruit_hcsr04.py
@@ -44,7 +44,7 @@ try:
     from pulseio import PulseIn
 
     _USE_PULSEIO = True
-except ImportError:
+except (ImportError, NotImplementedError):
     pass  # This is OK, we'll try to bitbang it!
 
 __version__ = "0.0.0+auto.0"


### PR DESCRIPTION
Currently adafruit_hcsr04.py checks for an ImportError when importing PulseIn from pulseio. If there is an ImportError, the code keeps _USE_PULSEIO as false and continues to function (well enough) without pulseio.

When running on the Jetson nano, we get a NotImplementedError instead. Since it isn't handled this exception crashes the script. If we add NotImplenetedError to the logic above however, it works fine. 

I'm using this fix to get my ultrasonics working on my robot https://github.com/scottmonaghan/robud